### PR TITLE
Added 'sudo' to rpm command; must run that command as su

### DIFF
--- a/Week-2/labs/LAB-3.md
+++ b/Week-2/labs/LAB-3.md
@@ -155,7 +155,7 @@ $ source ~/.bash_profile
 Install dependencies:
 
 ```
-$ rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm
+$ sudo rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm
 $ sudo yum -y install nodejs
 $ sudo yum -y install mariadb mariadb-server mariadb-devel
 $ sudo systemctl start mariadb.service


### PR DESCRIPTION
The rpm command to fedoraproject.org seems to need to run as a super user, otherwise it fails saying that it can't create a transaction lock and that permission is denied. Added sudo prior to command to fix the issue.
