### PR TITLE
Remove stale github link

### DIFF
--- a/Week-2/labs/LAB-3.md
+++ b/Week-2/labs/LAB-3.md
@@ -175,7 +175,7 @@ $ gem install rails --no-ri --no-rdoc
 Install and run app:
 
 ```
-$ git clone https://github.com/godinezj/myapp.git
+$ rails new myapp
 $ cd myapp
 $ bundle install
 $ bundle exec rake db:create


### PR DESCRIPTION
Replaced stale github link to base rails app with bootstrapping new rails app named myapp. Tested with all steps in the walkthrough.